### PR TITLE
Game engine glue revisions

### DIFF
--- a/content/blog/game-engine-glue/index.md
+++ b/content/blog/game-engine-glue/index.md
@@ -49,7 +49,7 @@ Let's begin with something controversial:
 
 Even taking the same code base,
 and using it for sequential games from the same studio doesn't work the same way.
-What [Factorio] did, what [Minecraft] did, what [the original Unreal] did?
+What [Factorio] did, what [Minecraft] did, what [Quake] did?
 Effective, but **not an engine!**
 
 Instead, they made something that could be replaced by a game engine,
@@ -81,7 +81,7 @@ past performance, as they say, is not a guarantee of future results.
 
 [Factorio]: https://www.factorio.com/
 [Minecraft]: https://www.minecraft.net/en-us
-[the original Unreal]: https://en.wikipedia.org/wiki/Unreal_(1998_video_game)
+[Quake]: https://www.gamedeveloper.com/design/classic-tools-retrospective-tim-sweeney-on-the-first-version-of-the-unreal-editor
 [RPGMaker]: https://www.rpgmakerweb.com/
 [Twine]: https://twinery.org/
 

--- a/content/blog/game-engine-glue/index.md
+++ b/content/blog/game-engine-glue/index.md
@@ -47,8 +47,6 @@ and why can't we make one by slapping high-quality libraries together in a stick
 Let's begin with something controversial:
 *a stack made for a single game is not a game engine*.
 
-Even taking the same code base,
-and using it for sequential games from the same studio doesn't work the same way.
 What [Factorio] did, what [Minecraft] did, what [Quake] did?
 Effective, but **not an engine!**
 

--- a/content/blog/game-engine-glue/index.md
+++ b/content/blog/game-engine-glue/index.md
@@ -88,7 +88,7 @@ past performance, as they say, is not a guarantee of future results.
 ## Dependencies are great, but glue code sucks
 
 Don't get me wrong: libaries rock, and dependencies are Good, Actually.
-Bevy has [dozens of them](https://crates.io/crates/bevy/latest/dependencies), both direct and transitive!
+Bevy has [dozens of them](https://crates.io/crates/bevy/0.7.0/dependencies), both direct and transitive!
 
 Without libraries, your velocity will crawl to a halt,
 and just as importantly, you won't be giving back to [the ecosystem](https://arewegameyet.rs/).


### PR DESCRIPTION
1. Fixes #189.
2. Swaps Unreal as an example of a standalone game stack for a less confusing and more historically accurate Quake.
Thanks to [Dave Watts on Twitter](https://twitter.com/therealdaveface/status/1550829033708986372).
3. Clarifies paragraph structure by removing a distracting sentence, thanks @DjMcNab for catching this.