### PR TITLE
Update social media links

### DIFF
--- a/content/team/index.md
+++ b/content/team/index.md
@@ -17,7 +17,7 @@ template="team.html"
 
 **Fun fact:** Despite the world's best efforts, somehow not dead yet!
 
-**Follow:** [Twitter](https://twitter.com/AliceICecile), [Twitch](https://www.twitch.tv/ivylashes), [Github](https://github.com/alice-i-cecile)
+**Follow:** [Mastodon](https://tech.lgbt/@alice_i_cecile), [Twitch](https://www.twitch.tv/ivylashes), [Github](https://github.com/alice-i-cecile)
 
 **Email:** [alice@leafwing-studios.com](mailto:alice@leafwing-studios.com)
 


### PR DESCRIPTION
Closes #208.

Replaces Alice's Twitter link with Mastodon.

If I should update any other social media links (e.g. for sixfold) let me know!
