### PR TITLE
Always apply a bit of padding to content

### DIFF
--- a/sass/lws.scss
+++ b/sass/lws.scss
@@ -55,9 +55,8 @@ figure {
 // Main content of document
 main {
     display: flex;
-    padding-top: 30px;
-    padding-bottom: 15px;
     flex-grow: 1;
+    padding: 1rem;
 }
 
 // Ensure footer is pushed to bottom
@@ -84,14 +83,6 @@ html {
         img {
             margin: 0;
         }
-    }
-
-    main {
-        padding: 30px;
-    }
-
-    .content {
-        padding: 0;
     }
 
     .explore-more,


### PR DESCRIPTION
# Objective

At some screen sizes, the content had no padding, which could lead to the scroll bar overlapping the text (and just a bad look IMO):
![The content on the main page directly touching the edges of the screen](https://user-images.githubusercontent.com/13908946/218566960-dd8c8044-9869-41f8-8936-b7d1ef97c3ca.png)

I simplified the padding definitions a bit and now always apply a padding to the main content to avoid these issues:
![Small padding around the content avoids the edge issue](https://user-images.githubusercontent.com/13908946/218567268-07d71242-889d-4977-9568-30c6d2e9b2b6.png)
